### PR TITLE
Optimization of styles

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,7 +1,7 @@
 <?php
 function my_theme_enqueue_styles() {
 	wp_enqueue_style( 'bootstrap_css', 'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css');
-	wp_enqueue_style('parent-theme', get_template_directory_uri() .'/style.css', 'bootstrap_css');
+	//wp_enqueue_style('parent-theme', get_template_directory_uri() .'/style.css', 'bootstrap_css'); //removed because it is automatically included from parent - Ryan
 }
 add_action( 'wp_enqueue_scripts', 'my_theme_enqueue_styles' );
 


### PR DESCRIPTION
Removed wp_enqueue of parent styles in functions.php. WP automatically adds parent styles. This will remove a duplication of css load.

P.S. child isn't used much, so I will not update it unless we collaborate otherwise.